### PR TITLE
feat: support gradio 5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gradio"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Jacob Lin <jacob@csie.cool>"]
 description = "Gradio Client in Rust."

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Gradio Client in Rust.
 - [x] Command-line interface
 - [x] Synchronous and asynchronous API
 
-> Supposed to work with Gradio 4, other versions are not tested.
+> Supposed to work with Gradio 5 & 4, other versions are not tested.
 
 ## Documentation
 

--- a/examples/whisper-turbo.rs
+++ b/examples/whisper-turbo.rs
@@ -1,0 +1,32 @@
+use gradio::{Client, ClientOptions, PredictionInput};
+
+#[tokio::main]
+async fn main() {
+    if std::env::args().len() < 2 {
+        println!("Please provide an audio file path as an argument");
+        std::process::exit(1);
+    }
+    let args: Vec<String> = std::env::args().collect();
+    let file_path = &args[1];
+    println!("File: {}", file_path);
+
+    // Gradio v5
+    let client = Client::new("hf-audio/whisper-large-v3-turbo", ClientOptions::default())
+        .await
+        .unwrap();
+
+    let output = client
+        .predict(
+            "/predict",
+            vec![
+                PredictionInput::from_file(file_path),
+                PredictionInput::from_value("transcribe"),
+            ],
+        )
+        .await
+        .unwrap();
+    println!(
+        "Output: {}",
+        output[0].clone().as_value().unwrap().as_str().unwrap()
+    );
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -83,7 +83,7 @@ impl Client {
 
         let http_client = Client::build_http_client(&options.hf_token)?;
 
-        let (api_root, space_id) =
+        let (mut api_root, space_id) =
             Client::resolve_app_reference(&http_client, app_reference).await?;
 
         if let Some((username, password)) = &options.auth {
@@ -95,6 +95,10 @@ impl Client {
         }
 
         let config = Client::fetch_config(&http_client, &api_root).await?;
+        if let Some(ref api_prefix) = config.api_prefix {
+            api_root.push_str(api_prefix);
+        }
+
         let api_info = Client::fetch_api_info(&http_client, &api_root).await?;
 
         Ok(Self {
@@ -229,9 +233,9 @@ impl Client {
         let json = res.json::<serde_json::Value>().await?;
         let config: AppConfigVersionOnly = serde_json::from_value(json.clone())?;
 
-        if !config.version.starts_with("4.") {
+        if !config.version.starts_with("5.") && !config.version.starts_with("4.") {
             eprintln!(
-                "Warning: This client is supposed to work with Gradio 4. The current version of the app is {}, which may cause issues.",
+                "Warning: This client is supposed to work with Gradio 5 & 4. The current version of the app is {}, which may cause issues.",
                 config.version
             );
         }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -33,6 +33,7 @@ pub struct AppConfig {
     pub theme_hash: Option<StringOrI64>,
     pub username: Option<String>,
     pub max_file_size: Option<i64>,
+    pub api_prefix: Option<String>,
     #[serde(default)]
     pub auth_required: Option<bool>,
     #[serde(default)]


### PR DESCRIPTION
- Support `api_prefix` from the config endpoint.