### PR TITLE
Add Gradio 6 support and typed library errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,4 +36,5 @@ reqwest = { version = "0.12.5", features = [
 reqwest-eventsource = "0.6.0"
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.120"
+thiserror = "1.0.63"
 tokio = { version = "1.38.1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Gradio Client in Rust.
 - [x] Command-line interface
 - [x] Synchronous and asynchronous API
 
-> Supposed to work with Gradio 5 & 4, other versions are not tested.
+> Supposed to work with Gradio 4, 5, and 6, other versions are not tested.
 
 ## Documentation
 
@@ -28,10 +28,10 @@ See the [examples](./examples/) directory for more examples.
 Here is an example of using `BS-RoFormer` model to separate vocals and background music from an audio file.
 
 ```rust
-use gradio::{PredictionInput, Client, ClientOptions};
+use gradio::{PredictionInput, Client, ClientOptions, Result};
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<()> {
     if std::env::args().len() < 2 {
         println!("Please provide an audio file path as an argument");
         std::process::exit(1);
@@ -41,8 +41,7 @@ async fn main() {
     println!("File: {}", file_path);
 
     let client = Client::new("JacobLinCool/vocal-separation", ClientOptions::default())
-        .await
-        .unwrap();
+        .await?;
 
     let output = client
         .predict(
@@ -52,8 +51,7 @@ async fn main() {
                 PredictionInput::from_value("BS-RoFormer"),
             ],
         )
-        .await
-        .unwrap();
+        .await?;
     println!(
         "Vocals: {}",
         output[0].clone().as_file().unwrap().url.unwrap()
@@ -62,10 +60,37 @@ async fn main() {
         "Background: {}",
         output[1].clone().as_file().unwrap().url.unwrap()
     );
+
+    Ok(())
 }
 ```
 
 See [./examples/sd3.rs](./examples/sd3.rs) for non-blocking example with `submit` method.
+
+## Errors
+
+The library now exposes `gradio::Error` and `gradio::Result<T>` as its primary error model.
+
+```rust
+use gradio::{Client, ClientOptions, Error, PredictionInput, Result};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let client = Client::new("gradio/hello_world", ClientOptions::default()).await?;
+
+    match client.predict("/missing", vec![PredictionInput::from_value("Rust")]).await {
+        Ok(output) => {
+            println!("{:?}", output);
+            Ok(())
+        }
+        Err(Error::InvalidRoute { route }) => {
+            eprintln!("Invalid route: {}", route);
+            Ok(())
+        }
+        Err(err) => Err(err),
+    }
+}
+```
 
 ## Command-line Interface
 

--- a/src/bin/gr.rs
+++ b/src/bin/gr.rs
@@ -111,9 +111,9 @@ async fn run_command(
     }
 
     let http_client = client.http_client.clone();
-    let mut prediction = client.submit(&route, data).await.unwrap();
+    let mut prediction = client.submit(&route, data).await?;
     while let Some(event) = prediction.next().await {
-        let event = event.unwrap();
+        let event = event?;
         match event {
             gradio::structs::QueueDataMessage::Estimation {
                 rank, queue_size, ..
@@ -136,7 +136,7 @@ async fn run_command(
                 }
             }
             gradio::structs::QueueDataMessage::ProcessCompleted { output, .. } => {
-                let output: Vec<PredictionOutput> = output.try_into().unwrap();
+                let output: Vec<PredictionOutput> = output.try_into()?;
 
                 for (i, ret) in endpoint.returns.iter().enumerate() {
                     let value = output.get(i).expect("Missing return value");
@@ -163,6 +163,12 @@ async fn run_command(
                     }
                 }
                 break;
+            }
+            gradio::structs::QueueDataMessage::UnexpectedError { message, .. } => {
+                return Err(anyhow::anyhow!(
+                    "{}",
+                    message.unwrap_or_else(|| "Unexpected error".to_string())
+                ));
             }
             _ => {}
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,3 @@
-use anyhow::{Error, Result};
 use rand::{distributions::Alphanumeric, Rng};
 use regex::Regex;
 
@@ -9,6 +8,7 @@ use crate::{
     data::{PredictionInput, PredictionOutput},
     space::wake_up_space,
     stream::PredictionStream,
+    Error, Result,
 };
 
 #[derive(Default)]
@@ -63,15 +63,16 @@ impl Client {
     /// # Example
     ///
     /// ```
-    /// use gradio::{Client, ClientOptions};
+    /// use gradio::{Client, ClientOptions, Result};
     ///
     /// #[tokio::main]
-    /// async fn main() {
+    /// async fn main() -> Result<()> {
     ///    let client = Client::new(
     ///         "gradio/hello_world",
     ///         ClientOptions::default()
-    ///     ).await.unwrap();
+    ///     ).await?;
     ///     println!("{:?}", client);
+    ///     Ok(())
     /// }
     /// ```
     pub async fn new(app_reference: &str, options: ClientOptions) -> Result<Self> {
@@ -96,7 +97,7 @@ impl Client {
 
         let config = Client::fetch_config(&http_client, &api_root).await?;
         if let Some(ref api_prefix) = config.api_prefix {
-            api_root.push_str(api_prefix);
+            api_root = Client::join_url_path(&api_root, api_prefix);
         }
 
         let api_info = Client::fetch_api_info(&http_client, &api_root).await?;
@@ -127,7 +128,14 @@ impl Client {
     ) -> Result<PredictionStream> {
         let data = preprocess_data(&self.http_client, &self.api_root, data).await?;
         let fn_index = Client::resolve_fn_index(&self.config, route)?;
-        PredictionStream::new(&self.http_client, &self.api_root, fn_index, data).await
+        PredictionStream::new(
+            &self.http_client,
+            &self.api_root,
+            &self.config.protocol,
+            fn_index,
+            data,
+        )
+        .await
     }
 
     pub async fn predict(
@@ -142,16 +150,19 @@ impl Client {
                     QueueDataMessage::Open
                     | QueueDataMessage::Estimation { .. }
                     | QueueDataMessage::ProcessStarts { .. }
+                    | QueueDataMessage::ProcessGenerating { .. }
+                    | QueueDataMessage::ProcessStreaming { .. }
                     | QueueDataMessage::Progress { .. }
                     | QueueDataMessage::Log { .. }
-                    | QueueDataMessage::Heartbeat => {}
+                    | QueueDataMessage::Heartbeat
+                    | QueueDataMessage::CloseStream => {}
                     QueueDataMessage::ProcessCompleted { output, .. } => {
                         return output.try_into();
                     }
-                    QueueDataMessage::UnexpectedError { message } => {
-                        return Err(Error::msg(
-                            message.unwrap_or_else(|| "Unexpected error".to_string()),
-                        ));
+                    QueueDataMessage::UnexpectedError { message, .. } => {
+                        return Err(Error::UnexpectedRemoteError {
+                            message: message.unwrap_or_else(|| "Unexpected error".to_string()),
+                        });
                     }
                     QueueDataMessage::Unknown(m) => {
                         eprintln!("[warning] Skipping unknown message: {:?}", m);
@@ -163,7 +174,7 @@ impl Client {
             }
         }
 
-        Err(Error::msg("Stream ended unexpectedly"))
+        Err(Error::StreamEndedUnexpectedly)
     }
 
     fn build_http_client(hf_token: &Option<String>) -> Result<reqwest::Client> {
@@ -178,7 +189,7 @@ impl Client {
                 )]));
         }
 
-        http_client_builder.build().map_err(Error::new)
+        http_client_builder.build().map_err(Error::from)
     }
 
     async fn resolve_app_reference(
@@ -186,8 +197,6 @@ impl Client {
         app_reference: &str,
     ) -> Result<(String, Option<String>)> {
         let app_reference = app_reference.trim_end_matches('/').to_string();
-        let mut api_root = app_reference.clone();
-        let mut space_id = None;
         if Regex::new("^[a-zA-Z0-9_\\-\\.]+\\/[a-zA-Z0-9_\\-\\.]+$")?.is_match(&app_reference) {
             let url = format!(
                 "https://huggingface.co/api/spaces/{}/{}",
@@ -195,13 +204,18 @@ impl Client {
             );
             let res = http_client.get(&url).send().await?;
             let res = res.json::<HuggingFaceAPIHost>().await?;
-            api_root.clone_from(&res.host);
-            space_id = Some(app_reference);
-        } else if Regex::new(".*hf\\.space\\/{0,1}$")?.is_match(&app_reference) {
-            space_id = Some(app_reference.replace(".hf.space", ""));
+            return Ok((res.host, Some(app_reference)));
         }
 
-        Ok((api_root, space_id))
+        if reqwest::Url::parse(&app_reference).is_ok() {
+            return Ok((app_reference, None));
+        }
+
+        if Regex::new("^[^/]+\\.hf\\.space(?:/.*)?$")?.is_match(&app_reference) {
+            return Ok((format!("https://{}", app_reference), None));
+        }
+
+        Ok((app_reference, None))
     }
 
     async fn authenticate(
@@ -216,7 +230,7 @@ impl Client {
             .send()
             .await?;
         if !res.status().is_success() {
-            return Err(Error::msg("Login failed"));
+            return Err(Error::LoginFailed);
         }
         Ok(())
     }
@@ -227,20 +241,20 @@ impl Client {
             .send()
             .await?;
         if !res.status().is_success() {
-            return Err(Error::msg("Could not resolve app config"));
+            return Err(Error::AppConfigUnavailable);
         }
 
         let json = res.json::<serde_json::Value>().await?;
         let config: AppConfigVersionOnly = serde_json::from_value(json.clone())?;
 
-        if !config.version.starts_with("5.") && !config.version.starts_with("4.") {
+        if !Client::supports_version(&config.version) {
             eprintln!(
-                "Warning: This client is supposed to work with Gradio 5 & 4. The current version of the app is {}, which may cause issues.",
+                "Warning: This client is supposed to work with Gradio 4, 5, and 6. The current version of the app is {}, which may cause issues.",
                 config.version
             );
         }
 
-        serde_json::from_value(json).map_err(Error::new)
+        serde_json::from_value(json).map_err(Error::from)
     }
 
     async fn fetch_api_info(http_client: &reqwest::Client, api_root: &str) -> Result<ApiInfo> {
@@ -249,9 +263,9 @@ impl Client {
             .send()
             .await?;
         if !res.status().is_success() {
-            return Err(Error::msg("Could not get API info"));
+            return Err(Error::ApiInfoUnavailable);
         }
-        res.json::<ApiInfo>().await.map_err(Error::new)
+        res.json::<ApiInfo>().await.map_err(Error::from)
     }
 
     fn resolve_fn_index(config: &AppConfig, route: &str) -> Result<i64> {
@@ -261,12 +275,59 @@ impl Client {
             .iter()
             .enumerate()
             .find(|(_i, d)| d.api_name == route)
-            .ok_or_else(|| Error::msg("Invalid route"))?;
+            .ok_or_else(|| Error::InvalidRoute {
+                route: route.to_string(),
+            })?;
 
         if found.1.id == -1 {
             Ok(found.0 as i64)
         } else {
             Ok(found.1.id)
         }
+    }
+
+    fn join_url_path(base: &str, suffix: &str) -> String {
+        let base = base.trim_end_matches('/');
+        let suffix = suffix.trim_matches('/');
+
+        if suffix.is_empty() {
+            base.to_string()
+        } else {
+            format!("{}/{}", base, suffix)
+        }
+    }
+
+    fn supports_version(version: &str) -> bool {
+        version
+            .split('.')
+            .next()
+            .and_then(|major| major.parse::<u64>().ok())
+            .is_some_and(|major| (4..=6).contains(&major))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Client;
+
+    #[test]
+    fn join_url_path_normalizes_slashes() {
+        assert_eq!(
+            Client::join_url_path("https://example.com/", "/gradio_api/"),
+            "https://example.com/gradio_api"
+        );
+        assert_eq!(
+            Client::join_url_path("https://example.com", "gradio_api"),
+            "https://example.com/gradio_api"
+        );
+    }
+
+    #[test]
+    fn supports_gradio_4_5_and_6() {
+        assert!(Client::supports_version("4.31.2"));
+        assert!(Client::supports_version("5.0.0"));
+        assert!(Client::supports_version("6.11.0"));
+        assert!(!Client::supports_version("7.0.0"));
+        assert!(!Client::supports_version("invalid"));
     }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,4 +1,3 @@
-use anyhow::{Error, Result};
 use serde::{Deserialize, Serialize};
 use std::{
     future::Future,
@@ -7,7 +6,7 @@ use std::{
 };
 use tokio::io::AsyncWriteExt;
 
-use crate::{constants::UPLOAD_URL, structs::QueueDataMessageOutput};
+use crate::{constants::UPLOAD_URL, structs::QueueDataMessageOutput, Error, Result};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum PredictionInput {
@@ -31,18 +30,18 @@ pub async fn upload_file(
     api_root: &str,
     path: PathBuf,
 ) -> Result<serde_json::Value> {
+    let file_name = path
+        .file_name()
+        .ok_or(Error::InvalidFilePath)?
+        .to_string_lossy()
+        .to_string();
+    let mime_type = mime_guess::from_path(&path)
+        .first_or_octet_stream()
+        .essence_str()
+        .to_string();
     let part = reqwest::multipart::Part::bytes(tokio::fs::read(&path).await?)
-        .file_name(
-            path.file_name()
-                .ok_or_else(|| Error::msg("Invalid file path"))?
-                .to_string_lossy()
-                .to_string(),
-        )
-        .mime_str(
-            mime_guess::from_path(&path)
-                .first_or_octet_stream()
-                .as_ref(),
-        )?;
+        .file_name(file_name.clone())
+        .mime_str(&mime_type)?;
     let form = reqwest::multipart::Form::new().part("files", part);
     let res = http_client
         .post(&format!("{}/{}", api_root, UPLOAD_URL))
@@ -50,16 +49,19 @@ pub async fn upload_file(
         .send()
         .await?;
     if !res.status().is_success() {
-        return Err(Error::msg("Error uploading file"));
+        return Err(Error::FileUploadFailed);
     }
     let res = res.json::<Vec<String>>().await?;
     if res.len() != 1 {
-        return Err(Error::msg("Invalid file upload response"));
+        return Err(Error::InvalidFileUploadResponse);
     }
 
     let json = serde_json::json!({
         "path": res[0],
-        "orig_name": path.to_string_lossy(),
+        "url": serde_json::Value::Null,
+        "orig_name": file_name,
+        "mime_type": mime_type,
+        "is_stream": false,
         "meta": {
             "_type": "gradio.FileData"
         }
@@ -118,14 +120,14 @@ impl PredictionOutput {
     pub fn as_file(self) -> Result<GradioFileData> {
         match self {
             Self::File(file) => Ok(file),
-            _ => Err(anyhow::anyhow!("Expected file output")),
+            _ => Err(Error::ExpectedFileOutput),
         }
     }
 
     pub fn as_value(self) -> Result<serde_json::Value> {
         match self {
             Self::Value(value) => Ok(value),
-            _ => Err(anyhow::anyhow!("Expected value output")),
+            _ => Err(Error::ExpectedValueOutput),
         }
     }
 }
@@ -137,6 +139,9 @@ pub struct GradioFileData {
     pub meta: GradioFileDataMeta,
     pub url: Option<String>,
     pub size: Option<usize>,
+    pub mime_type: Option<String>,
+    #[serde(default)]
+    pub is_stream: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -145,7 +150,7 @@ pub struct GradioFileDataMeta {
 }
 
 impl TryFrom<QueueDataMessageOutput> for Vec<PredictionOutput> {
-    type Error = anyhow::Error;
+    type Error = Error;
 
     fn try_from(value: QueueDataMessageOutput) -> Result<Self> {
         match value {
@@ -156,9 +161,9 @@ impl TryFrom<QueueDataMessageOutput> for Vec<PredictionOutput> {
                 }
                 Ok(outputs)
             }
-            QueueDataMessageOutput::Error { error } => {
-                Err(anyhow::anyhow!(error.unwrap_or("Unknown error".to_string())))
-            }
+            QueueDataMessageOutput::Error { error, .. } => Err(Error::RemoteError {
+                message: error.unwrap_or_else(|| "Unknown error".to_string()),
+            }),
         }
     }
 }
@@ -175,7 +180,7 @@ impl GradioFileData {
             let content = response.bytes().await?;
             Ok(content)
         } else {
-            Err(Error::msg("No URL available for file"))
+            Err(Error::NoFileUrl)
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,84 @@
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    Http(#[from] reqwest::Error),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Regex(#[from] regex::Error),
+    #[error(transparent)]
+    InvalidHeaderValue(#[from] reqwest::header::InvalidHeaderValue),
+    #[error(transparent)]
+    EventSource(#[from] reqwest_eventsource::CannotCloneRequestError),
+
+    #[error("login failed")]
+    LoginFailed,
+    #[error("could not resolve app config")]
+    AppConfigUnavailable,
+    #[error("could not get API info")]
+    ApiInfoUnavailable,
+    #[error("invalid route: {route}")]
+    InvalidRoute { route: String },
+    #[error("cannot join task queue")]
+    CannotJoinTaskQueue,
+    #[error("stream ended unexpectedly")]
+    StreamEndedUnexpectedly,
+    #[error("stream ended")]
+    StreamEnded,
+    #[error("unexpected remote error: {message}")]
+    UnexpectedRemoteError { message: String },
+    #[error("remote error: {message}")]
+    RemoteError { message: String },
+    #[error("invalid file path")]
+    InvalidFilePath,
+    #[error("error uploading file")]
+    FileUploadFailed,
+    #[error("invalid file upload response")]
+    InvalidFileUploadResponse,
+    #[error("expected file output")]
+    ExpectedFileOutput,
+    #[error("expected value output")]
+    ExpectedValueOutput,
+    #[error("no URL available for file")]
+    NoFileUrl,
+    #[error("could not get space status")]
+    SpaceStatusUnavailable,
+    #[error("space {space_id} is paused by the author")]
+    SpacePaused { space_id: String },
+    #[error("unknown runtime stage {stage} for space {space_id}")]
+    UnknownRuntimeStage { stage: String, space_id: String },
+    #[error("space {space_id} is taking too long to start")]
+    SpaceStartupTimeout { space_id: String },
+    #[error("server error: {message}")]
+    ServerProtocol { message: String },
+    #[error("client error: {message}")]
+    ClientProtocol { message: String },
+    #[error("invalid diff operation payload")]
+    InvalidDiffOperationPayload,
+    #[error("diff action must be a string")]
+    DiffActionMustBeString,
+    #[error("diff path must be an array")]
+    DiffPathMustBeArray,
+    #[error("diff path segment must be a string or integer")]
+    InvalidDiffPathSegment,
+    #[error("array diff path must use integer indexes")]
+    ArrayDiffPathMustUseIndexes,
+    #[error("diff index out of bounds")]
+    DiffIndexOutOfBounds,
+    #[error("object diff path must use string keys")]
+    ObjectDiffPathMustUseKeys,
+    #[error("diff key not found")]
+    DiffKeyNotFound,
+    #[error("cannot apply nested diff to scalar value")]
+    CannotApplyNestedDiffToScalar,
+    #[error("unsupported root diff action: {action}")]
+    UnsupportedRootDiffAction { action: String },
+    #[error("unknown diff action: {action}")]
+    UnknownDiffAction { action: String },
+    #[error("append diff requires string or array values")]
+    AppendDiffTypeMismatch,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,13 @@
+//! Rust client library for Gradio apps and Hugging Face Spaces.
+//!
+//! The primary error model is [`Error`] and [`Result<T>`].
+//! `anyhow` is still re-exported temporarily for downstream compatibility,
+//! but new code should prefer `gradio::Error` and `gradio::Result<T>`.
+//!
 pub mod client;
 pub mod constants;
 pub mod data;
+pub mod error;
 pub mod space;
 pub mod stream;
 pub mod structs;
@@ -8,9 +15,10 @@ pub mod sync;
 
 pub use client::*;
 pub use data::*;
+pub use error::*;
 pub use stream::*;
 
-// re-export anyhow, serde, and tokio for convenience
+// Re-export anyhow for downstream compatibility during the error-model transition.
 pub use anyhow;
 pub use serde;
 pub use tokio;

--- a/src/space.rs
+++ b/src/space.rs
@@ -1,5 +1,4 @@
-use crate::constants::*;
-use anyhow::{Error, Result};
+use crate::{Error, Result};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -44,7 +43,7 @@ pub async fn wake_up_space(client: &reqwest::Client, space_id: &str) -> Result<(
             .send()
             .await?;
         if !response.status().is_success() {
-            return Err(Error::msg(SPACE_STATUS_ERROR_MSG));
+            return Err(Error::SpaceStatusUnavailable);
         }
 
         let status = response.json::<SpaceStatus>().await?;
@@ -56,27 +55,25 @@ pub async fn wake_up_space(client: &reqwest::Client, space_id: &str) -> Result<(
                 // keep trying
             }
             SpaceStatusRuntimeStage::Paused => {
-                return Err(Error::msg(format!(
-                    "Space {} is paused by the author.",
-                    space_id
-                )));
+                return Err(Error::SpacePaused {
+                    space_id: space_id.to_string(),
+                });
             }
             SpaceStatusRuntimeStage::Running | SpaceStatusRuntimeStage::RunningBuilding => {
                 return Ok(());
             }
             SpaceStatusRuntimeStage::Unknown(s) => {
-                return Err(Error::msg(format!(
-                    "Unknown runtime stage {} for space {}",
-                    s, space_id
-                )));
+                return Err(Error::UnknownRuntimeStage {
+                    stage: s,
+                    space_id: space_id.to_string(),
+                });
             }
         }
 
         if retries >= max_retries {
-            return Err(Error::msg(format!(
-                "Space {} is taking too long to start.",
-                space_id
-            )));
+            return Err(Error::SpaceStartupTimeout {
+                space_id: space_id.to_string(),
+            });
         }
         retries += 1;
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,9 +1,11 @@
-use anyhow::{Error, Result};
 use futures_util::stream::StreamExt;
 use rand::{distributions::Alphanumeric, Rng};
 use reqwest_eventsource::{Event, EventSource};
 
-use crate::structs::{QueueDataMessage, QueueJoinResponse};
+use crate::{
+    structs::{QueueDataMessage, QueueDataMessageOutput, QueueJoinResponse},
+    Error, Result,
+};
 
 pub struct PredictionStream {
     pub es: EventSource,
@@ -12,12 +14,15 @@ pub struct PredictionStream {
     pub session_hash: String,
     pub event_id: String,
     pub fn_index: i64,
+    protocol: String,
+    pending_diff_streams: Option<Vec<serde_json::Value>>,
 }
 
 impl PredictionStream {
     pub async fn new(
         http_client: &reqwest::Client,
         api_root: &str,
+        protocol: &str,
         fn_index: impl Into<i64>,
         data: Vec<serde_json::Value>,
     ) -> Result<Self> {
@@ -39,7 +44,7 @@ impl PredictionStream {
         });
         let res = http_client.post(&url).json(&payload).send().await?;
         if !res.status().is_success() {
-            return Err(Error::msg("Cannot join task queue"));
+            return Err(Error::CannotJoinTaskQueue);
         }
         let res = res.json::<QueueJoinResponse>().await?;
         let event_id = res.event_id;
@@ -54,23 +59,43 @@ impl PredictionStream {
             session_hash,
             event_id,
             fn_index,
+            protocol: protocol.to_string(),
+            pending_diff_streams: None,
         })
     }
 
     pub async fn next(&mut self) -> Option<Result<QueueDataMessage>> {
         let event = self.es.next().await;
         if event.is_none() {
-            return Some(Err(Error::msg("Stream ended")));
+            return Some(Err(Error::StreamEnded));
         }
         let event = event.unwrap();
 
         match event {
             Ok(Event::Open) => Some(Ok(QueueDataMessage::Open)),
             Ok(Event::Message(message)) => match serde_json::from_str(&message.data) {
-                Ok(message) => Some(Ok(message)),
-                Err(err) => Some(Err(Error::msg(format!("Server Error: {:#?}", err)))),
+                Ok(mut queue_message) => {
+                    if let Err(err) = normalize_queue_message(
+                        &self.protocol,
+                        &mut self.pending_diff_streams,
+                        &mut queue_message,
+                    ) {
+                        return Some(Err(err));
+                    }
+
+                    if matches!(queue_message, QueueDataMessage::CloseStream) {
+                        self.es.close();
+                    }
+
+                    Some(Ok(queue_message))
+                }
+                Err(err) => Some(Err(Error::ServerProtocol {
+                    message: format!("{:#?}", err),
+                })),
             },
-            Err(err) => Some(Err(Error::msg(format!("Client Error: {:#?}", err)))),
+            Err(err) => Some(Err(Error::ClientProtocol {
+                message: format!("{:#?}", err),
+            })),
         }
     }
 
@@ -92,5 +117,346 @@ impl PredictionStream {
         let _ = self.http_client.post(&url).json(&payload).send().await;
 
         Ok(())
+    }
+}
+
+fn normalize_queue_message(
+    protocol: &str,
+    pending_diff_streams: &mut Option<Vec<serde_json::Value>>,
+    message: &mut QueueDataMessage,
+) -> Result<()> {
+    match message {
+        QueueDataMessage::ProcessGenerating {
+            output, success, ..
+        }
+        | QueueDataMessage::ProcessStreaming {
+            output, success, ..
+        } => {
+            if *success {
+                normalize_diff_output(protocol, pending_diff_streams, output)?;
+            }
+        }
+        QueueDataMessage::ProcessCompleted { .. }
+        | QueueDataMessage::UnexpectedError { .. }
+        | QueueDataMessage::CloseStream => {
+            *pending_diff_streams = None;
+        }
+        _ => {}
+    }
+
+    Ok(())
+}
+
+fn normalize_diff_output(
+    protocol: &str,
+    pending_diff_streams: &mut Option<Vec<serde_json::Value>>,
+    output: &mut QueueDataMessageOutput,
+) -> Result<()> {
+    if !supports_diff_stream(protocol) {
+        return Ok(());
+    }
+
+    let Some(data) = output.data_mut() else {
+        return Ok(());
+    };
+
+    if pending_diff_streams.is_none() {
+        *pending_diff_streams = Some(data.clone());
+        return Ok(());
+    }
+
+    let pending = pending_diff_streams
+        .as_mut()
+        .expect("pending diff streams should exist");
+    for (index, value) in data.iter_mut().enumerate() {
+        let previous = pending
+            .get(index)
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        let normalized = apply_diff(previous, value.clone())?;
+
+        if index < pending.len() {
+            pending[index] = normalized.clone();
+        } else {
+            pending.push(normalized.clone());
+        }
+
+        *value = normalized;
+    }
+
+    Ok(())
+}
+
+fn supports_diff_stream(protocol: &str) -> bool {
+    matches!(protocol, "sse_v2" | "sse_v2.1" | "sse_v3")
+}
+
+fn apply_diff(target: serde_json::Value, diff: serde_json::Value) -> Result<serde_json::Value> {
+    let Some(ops) = diff.as_array() else {
+        return Ok(diff);
+    };
+
+    if !ops.iter().all(is_diff_operation) {
+        return Ok(diff);
+    }
+
+    let mut output = target;
+    for op in ops {
+        let op = op.as_array().ok_or(Error::InvalidDiffOperationPayload)?;
+        let action = op[0].as_str().ok_or(Error::DiffActionMustBeString)?;
+        let path = parse_path_segments(&op[1])?;
+        let value = op[2].clone();
+        output = apply_edit(output, &path, action, value)?;
+    }
+
+    Ok(output)
+}
+
+fn is_diff_operation(value: &serde_json::Value) -> bool {
+    let Some(op) = value.as_array() else {
+        return false;
+    };
+
+    if op.len() != 3 {
+        return false;
+    }
+
+    op[0].is_string() && op[1].is_array()
+}
+
+#[derive(Clone, Debug)]
+enum PathSegment {
+    Index(usize),
+    Key(String),
+}
+
+fn parse_path_segments(path: &serde_json::Value) -> Result<Vec<PathSegment>> {
+    let Some(path) = path.as_array() else {
+        return Err(Error::DiffPathMustBeArray);
+    };
+
+    path.iter()
+        .map(|segment| {
+            if let Some(index) = segment.as_u64() {
+                Ok(PathSegment::Index(index as usize))
+            } else if let Some(key) = segment.as_str() {
+                Ok(PathSegment::Key(key.to_string()))
+            } else {
+                Err(Error::InvalidDiffPathSegment)
+            }
+        })
+        .collect()
+}
+
+fn apply_edit(
+    target: serde_json::Value,
+    path: &[PathSegment],
+    action: &str,
+    value: serde_json::Value,
+) -> Result<serde_json::Value> {
+    if path.is_empty() {
+        return apply_root_edit(target, action, value);
+    }
+
+    match target {
+        serde_json::Value::Array(mut items) => {
+            let PathSegment::Index(index) = &path[0] else {
+                return Err(Error::ArrayDiffPathMustUseIndexes);
+            };
+            let index = *index;
+
+            if path.len() == 1 {
+                match action {
+                    "replace" => {
+                        let slot = items.get_mut(index).ok_or(Error::DiffIndexOutOfBounds)?;
+                        *slot = value;
+                    }
+                    "append" => {
+                        let slot = items.get_mut(index).ok_or(Error::DiffIndexOutOfBounds)?;
+                        append_value(slot, value)?;
+                    }
+                    "add" => {
+                        if index > items.len() {
+                            return Err(Error::DiffIndexOutOfBounds);
+                        }
+                        items.insert(index, value);
+                    }
+                    "delete" => {
+                        if index >= items.len() {
+                            return Err(Error::DiffIndexOutOfBounds);
+                        }
+                        items.remove(index);
+                    }
+                    _ => {
+                        return Err(Error::UnknownDiffAction {
+                            action: action.to_string(),
+                        });
+                    }
+                }
+            } else {
+                let slot = items.get_mut(index).ok_or(Error::DiffIndexOutOfBounds)?;
+                let child = std::mem::take(slot);
+                *slot = apply_edit(child, &path[1..], action, value)?;
+            }
+
+            Ok(serde_json::Value::Array(items))
+        }
+        serde_json::Value::Object(mut fields) => {
+            let PathSegment::Key(key) = &path[0] else {
+                return Err(Error::ObjectDiffPathMustUseKeys);
+            };
+
+            if path.len() == 1 {
+                match action {
+                    "replace" => {
+                        fields.insert(key.clone(), value);
+                    }
+                    "append" => {
+                        let slot = fields.get_mut(key).ok_or(Error::DiffKeyNotFound)?;
+                        append_value(slot, value)?;
+                    }
+                    "add" => {
+                        fields.insert(key.clone(), value);
+                    }
+                    "delete" => {
+                        fields.remove(key);
+                    }
+                    _ => {
+                        return Err(Error::UnknownDiffAction {
+                            action: action.to_string(),
+                        });
+                    }
+                }
+            } else {
+                let slot = fields.get_mut(key).ok_or(Error::DiffKeyNotFound)?;
+                let child = std::mem::take(slot);
+                *slot = apply_edit(child, &path[1..], action, value)?;
+            }
+
+            Ok(serde_json::Value::Object(fields))
+        }
+        _ => Err(Error::CannotApplyNestedDiffToScalar),
+    }
+}
+
+fn apply_root_edit(
+    target: serde_json::Value,
+    action: &str,
+    value: serde_json::Value,
+) -> Result<serde_json::Value> {
+    match action {
+        "replace" => Ok(value),
+        "append" => append_root_value(target, value),
+        _ => Err(Error::UnsupportedRootDiffAction {
+            action: action.to_string(),
+        }),
+    }
+}
+
+fn append_root_value(
+    target: serde_json::Value,
+    value: serde_json::Value,
+) -> Result<serde_json::Value> {
+    match (target, value) {
+        (serde_json::Value::String(mut lhs), serde_json::Value::String(rhs)) => {
+            lhs.push_str(&rhs);
+            Ok(serde_json::Value::String(lhs))
+        }
+        (serde_json::Value::Array(mut lhs), serde_json::Value::Array(rhs)) => {
+            lhs.extend(rhs);
+            Ok(serde_json::Value::Array(lhs))
+        }
+        _ => Err(Error::AppendDiffTypeMismatch),
+    }
+}
+
+fn append_value(target: &mut serde_json::Value, value: serde_json::Value) -> Result<()> {
+    let new_value = append_root_value(std::mem::take(target), value)?;
+    *target = new_value;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{apply_diff, normalize_queue_message};
+    use crate::structs::{QueueDataMessage, QueueDataMessageOutput};
+
+    #[test]
+    fn applies_nested_diff_operations() {
+        let base = json!({
+            "text": "hel",
+            "items": [1, 3]
+        });
+        let diff = json!([["append", ["text"], "lo"], ["add", ["items", 1], 2]]);
+
+        let applied = apply_diff(base, diff).unwrap();
+
+        assert_eq!(
+            applied,
+            json!({
+                "text": "hello",
+                "items": [1, 2, 3]
+            })
+        );
+    }
+
+    #[test]
+    fn ignores_non_diff_payloads() {
+        let value = json!({"text": "hello"});
+        assert_eq!(apply_diff(json!("ignored"), value.clone()).unwrap(), value);
+    }
+
+    #[test]
+    fn normalizes_process_generating_diffs_for_sse_v3() {
+        let mut pending = None;
+        let mut first = QueueDataMessage::ProcessGenerating {
+            event_id: Some("evt".to_string()),
+            output: QueueDataMessageOutput::Success {
+                data: vec![json!("Hel")],
+                duration: None,
+                render_config: None,
+                changed_state_ids: None,
+            },
+            success: true,
+            time_limit: None,
+            progress_data: None,
+        };
+        normalize_queue_message("sse_v3", &mut pending, &mut first).unwrap();
+
+        let mut second = QueueDataMessage::ProcessGenerating {
+            event_id: Some("evt".to_string()),
+            output: QueueDataMessageOutput::Success {
+                data: vec![json!([["append", [], "lo"]])],
+                duration: None,
+                render_config: None,
+                changed_state_ids: None,
+            },
+            success: true,
+            time_limit: None,
+            progress_data: None,
+        };
+        normalize_queue_message("sse_v3", &mut pending, &mut second).unwrap();
+
+        match second {
+            QueueDataMessage::ProcessGenerating { output, .. } => match output {
+                QueueDataMessageOutput::Success { data, .. } => {
+                    assert_eq!(data, vec![json!("Hello")]);
+                }
+                QueueDataMessageOutput::Error { .. } => panic!("expected success output"),
+            },
+            _ => panic!("expected process generating message"),
+        }
+    }
+
+    #[test]
+    fn clears_pending_diffs_when_stream_closes() {
+        let mut pending = Some(vec![json!("Hello")]);
+        let mut message = QueueDataMessage::CloseStream;
+
+        normalize_queue_message("sse_v3", &mut pending, &mut message).unwrap();
+
+        assert!(pending.is_none());
     }
 }

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -136,12 +136,28 @@ pub enum QueueDataMessage {
         event_id: Option<String>,
         rank: i64,
         queue_size: i64,
-        rank_eta: f64,
+        rank_eta: Option<f64>,
     },
     #[serde(rename = "process_starts")]
     ProcessStarts {
         event_id: Option<String>,
         eta: Option<f64>,
+        progress_data: Option<Vec<ProcessingProgressData>>,
+    },
+    #[serde(rename = "process_generating")]
+    ProcessGenerating {
+        event_id: Option<String>,
+        output: QueueDataMessageOutput,
+        success: bool,
+        time_limit: Option<f64>,
+        progress_data: Option<Vec<ProcessingProgressData>>,
+    },
+    #[serde(rename = "process_streaming")]
+    ProcessStreaming {
+        event_id: Option<String>,
+        output: QueueDataMessageOutput,
+        success: bool,
+        time_limit: Option<f64>,
         progress_data: Option<Vec<ProcessingProgressData>>,
     },
     #[serde(rename = "log")]
@@ -161,12 +177,17 @@ pub enum QueueDataMessage {
         event_id: Option<String>,
         output: QueueDataMessageOutput,
         success: bool,
+        progress_data: Option<Vec<ProcessingProgressData>>,
     },
     #[serde(rename = "unexpected_error")]
     UnexpectedError {
         message: Option<String>,
+        session_not_found: Option<bool>,
+        success: Option<bool>,
     },
     Open,
+    #[serde(rename = "close_stream")]
+    CloseStream,
     #[serde(untagged)]
     Unknown(serde_json::Value),
 }
@@ -176,10 +197,15 @@ pub enum QueueDataMessage {
 pub enum QueueDataMessageOutput {
     Success {
         data: Vec<serde_json::Value>,
-        duration: f64,
+        duration: Option<f64>,
+        render_config: Option<serde_json::Value>,
+        changed_state_ids: Option<Vec<serde_json::Value>>,
     },
     Error {
         error: Option<String>,
+        title: Option<String>,
+        duration: Option<f64>,
+        visible: Option<bool>,
     },
 }
 
@@ -188,4 +214,15 @@ pub struct ProcessingProgressData {
     pub index: usize,
     pub length: Option<usize>,
     pub unit: String,
+    pub progress: Option<f64>,
+    pub desc: Option<String>,
+}
+
+impl QueueDataMessageOutput {
+    pub fn data_mut(&mut self) -> Option<&mut Vec<serde_json::Value>> {
+        match self {
+            Self::Success { data, .. } => Some(data),
+            Self::Error { .. } => None,
+        }
+    }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -2,7 +2,7 @@ use crate::client::{Client, ClientOptions};
 use crate::data::{GradioFileData, PredictionInput, PredictionOutput};
 use crate::stream::PredictionStream;
 use crate::structs::QueueDataMessage;
-use anyhow::{Error, Result};
+use crate::Result;
 use std::path::Path;
 use tokio::runtime::Runtime;
 
@@ -54,11 +54,10 @@ impl GradioFileData {
 
 impl PredictionStream {
     pub fn next_sync(&mut self) -> Option<Result<QueueDataMessage>> {
-        let rt = Runtime::new();
-        if rt.is_err() {
-            return Some(Err(Error::msg("Runtime error")));
-        }
-        let rt = rt.unwrap();
+        let rt = match Runtime::new() {
+            Ok(rt) => rt,
+            Err(err) => return Some(Err(err.into())),
+        };
         let output = rt.block_on(self.next())?;
         Some(output)
     }

--- a/tests/live_spaces.rs
+++ b/tests/live_spaces.rs
@@ -1,0 +1,113 @@
+use anyhow::Result;
+use gradio::{Client, ClientOptions, PredictionInput};
+
+const SAMPLE_AUDIO_URL: &str =
+    "https://github.com/gradio-app/gradio/raw/main/test/test_files/audio_sample.wav";
+const SAMPLE_AUDIO_PATH: &str = "/tmp/gradio-rs-live-audio-sample.wav";
+const SAMPLE_MODEL_URL: &str =
+    "https://raw.githubusercontent.com/gradio-app/gradio/main/gradio/media_assets/models3d/Fox.gltf";
+const SAMPLE_MODEL_PATH: &str = "/tmp/gradio-rs-live-model-sample.gltf";
+
+async fn ensure_sample_audio() -> Result<&'static str> {
+    if tokio::fs::try_exists(SAMPLE_AUDIO_PATH).await? {
+        return Ok(SAMPLE_AUDIO_PATH);
+    }
+
+    let bytes = reqwest::get(SAMPLE_AUDIO_URL).await?.bytes().await?;
+    tokio::fs::write(SAMPLE_AUDIO_PATH, bytes).await?;
+    Ok(SAMPLE_AUDIO_PATH)
+}
+
+async fn ensure_sample_model() -> Result<&'static str> {
+    if tokio::fs::try_exists(SAMPLE_MODEL_PATH).await? {
+        return Ok(SAMPLE_MODEL_PATH);
+    }
+
+    let bytes = reqwest::get(SAMPLE_MODEL_URL).await?.bytes().await?;
+    tokio::fs::write(SAMPLE_MODEL_PATH, bytes).await?;
+    Ok(SAMPLE_MODEL_PATH)
+}
+
+#[tokio::test]
+#[ignore = "requires live Hugging Face Spaces"]
+async fn gradio_6_space_id_predicts_successfully() -> Result<()> {
+    let client = Client::new("gradio/hello_world", ClientOptions::default()).await?;
+    let output = client
+        .predict("/predict", vec![PredictionInput::from_value("Jacob")])
+        .await?;
+
+    assert_eq!(output[0].clone().as_value()?.as_str(), Some("Hello Jacob!"));
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "requires live Hugging Face Spaces"]
+async fn gradio_6_full_url_predicts_successfully() -> Result<()> {
+    let client = Client::new(
+        "https://gradio-hello-world.hf.space",
+        ClientOptions::default(),
+    )
+    .await?;
+    let output = client
+        .predict("/predict", vec![PredictionInput::from_value("Rust")])
+        .await?;
+
+    assert_eq!(output[0].clone().as_value()?.as_str(), Some("Hello Rust!"));
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "requires live Hugging Face Spaces"]
+async fn gradio_6_file_upload_prediction_works() -> Result<()> {
+    let sample_model = ensure_sample_model().await?;
+    let client = Client::new("gradio/model3D", ClientOptions::default()).await?;
+    let output = client
+        .predict("/predict", vec![PredictionInput::from_file(sample_model)])
+        .await?;
+
+    let model = output[0].clone().as_file()?;
+    assert_eq!(model.meta._type, "gradio.FileData");
+    assert!(
+        model
+            .url
+            .as_deref()
+            .map(|url| !url.is_empty())
+            .unwrap_or(false)
+            || model
+                .path
+                .as_deref()
+                .map(|path| !path.is_empty())
+                .unwrap_or(false)
+    );
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "requires live Hugging Face Spaces"]
+async fn gradio_5_file_upload_prediction_works() -> Result<()> {
+    let sample_audio = ensure_sample_audio().await?;
+    let client = Client::new("hf-audio/whisper-large-v3-turbo", ClientOptions::default()).await?;
+    let output = client
+        .predict(
+            "/predict",
+            vec![
+                PredictionInput::from_file(sample_audio),
+                PredictionInput::from_value("transcribe"),
+            ],
+        )
+        .await?;
+
+    let transcript = output[0].clone().as_value()?;
+    assert!(transcript.as_str().unwrap_or("").trim().len() > 1);
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "requires live Hugging Face Spaces"]
+async fn gradio_4_space_metadata_is_available() -> Result<()> {
+    let client = Client::new("JacobLinCool/vocal-separation", ClientOptions::default()).await?;
+    let api = client.view_api();
+
+    assert!(api.named_endpoints.contains_key("/separate"));
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- expand gradio-rs compatibility to Gradio 6 while keeping Gradio 4 and 5 working
- add a typed library error model with `gradio::Error` and `gradio::Result`
- add live Hugging Face Space tests covering Gradio 4, 5, and 6

## Details
- normalize `api_prefix` handling and accept direct `hf.space` URLs more robustly
- support newer queue messages such as `process_generating`, `process_streaming`, and `close_stream`
- apply SSE diff patches for `sse_v2`, `sse_v2.1`, and `sse_v3`
- align uploaded and returned `FileData` with newer Gradio schemas
- keep `pub use anyhow;` temporarily for downstream compatibility with `gradio_macro`
- update README and doctests to prefer `gradio::Error` and `gradio::Result`

## Testing
- cargo test
- cargo test --test live_spaces -- --ignored --nocapture